### PR TITLE
#1462 replaced File listFiles with Path

### DIFF
--- a/cobigen/cobigen-core/src/main/java/com/devonfw/cobigen/impl/config/constant/WikiConstants.java
+++ b/cobigen/cobigen-core/src/main/java/com/devonfw/cobigen/impl/config/constant/WikiConstants.java
@@ -1,0 +1,7 @@
+package com.devonfw.cobigen.impl.config.constant;
+
+public class WikiConstants {
+
+  public final static String WIKI_UPDATE_OLD_CONFIG = "https://github.com/devonfw/cobigen/wiki/cobigen-core_configuration#update-old-config%22);";
+
+}

--- a/cobigen/cobigen-core/src/main/java/com/devonfw/cobigen/impl/config/upgrade/ContextConfigurationUpgrader.java
+++ b/cobigen/cobigen-core/src/main/java/com/devonfw/cobigen/impl/config/upgrade/ContextConfigurationUpgrader.java
@@ -37,24 +37,24 @@ public class ContextConfigurationUpgrader extends AbstractConfigurationUpgrader<
 
     switch (source) {
       case v2_0:
-        // to v2.1
+        // to v2.2
 
         MapperFactory mapperFactory = new DefaultMapperFactory.Builder().useAutoMapping(true).mapNulls(true).build();
         mapperFactory
             .classMap(com.devonfw.cobigen.impl.config.entity.io.v2_0.ContextConfiguration.class,
-                com.devonfw.cobigen.impl.config.entity.io.v2_1.ContextConfiguration.class)
+                com.devonfw.cobigen.impl.config.entity.io.v2_2.ContextConfiguration.class)
             .field("triggers.trigger", "trigger").byDefault().register();
         mapperFactory
             .classMap(com.devonfw.cobigen.impl.config.entity.io.v2_0.ContainerMatcher.class,
-                com.devonfw.cobigen.impl.config.entity.io.v2_1.ContainerMatcher.class)
+                com.devonfw.cobigen.impl.config.entity.io.v2_2.ContainerMatcher.class)
             .field(
                 "retrieveObjectsRecursively:{isRetrieveObjectsRecursively|setRetrieveObjectsRecursively(new Boolean(%s))|type=java.lang.Boolean}",
                 "retrieveObjectsRecursively:{isRetrieveObjectsRecursively|setRetrieveObjectsRecursively(new Boolean(%s))|type=java.lang.Boolean}")
             .byDefault().register();
         MapperFacade mapper = mapperFactory.getMapperFacade();
-        com.devonfw.cobigen.impl.config.entity.io.v2_1.ContextConfiguration upgradedConfig = mapper.map(
-            previousConfigurationRootNode, com.devonfw.cobigen.impl.config.entity.io.v2_1.ContextConfiguration.class);
-        upgradedConfig.setVersion(new BigDecimal("2.1"));
+        com.devonfw.cobigen.impl.config.entity.io.v2_2.ContextConfiguration upgradedConfig = mapper.map(
+            previousConfigurationRootNode, com.devonfw.cobigen.impl.config.entity.io.v2_2.ContextConfiguration.class);
+        upgradedConfig.setVersion(new BigDecimal("2.2"));
 
         result.setResultConfigurationJaxbRootNode(upgradedConfig);
 

--- a/cobigen/cobigen-core/src/test/java/com/devonfw/cobigen/unittest/config/reader/ContextConfigurationReaderTest.java
+++ b/cobigen/cobigen-core/src/test/java/com/devonfw/cobigen/unittest/config/reader/ContextConfigurationReaderTest.java
@@ -1,5 +1,7 @@
 package com.devonfw.cobigen.unittest.config.reader;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.nio.file.Paths;
 
@@ -31,6 +33,42 @@ public class ContextConfigurationReaderTest extends AbstractUnitTest {
   public void testErrorOnInvalidConfiguration() throws InvalidConfigurationException {
 
     new ContextConfigurationReader(Paths.get(new File(testFileRootPath + "faulty").toURI()));
+  }
+
+  /**
+   * Tests v2.2 context configuration reading two templates with context.xmls
+   *
+   */
+  @Test
+  public void testNewModularConfiguration() {
+
+    ContextConfigurationReader context = new ContextConfigurationReader(
+        Paths.get(new File(testFileRootPath + "valid_new").toURI()));
+    assertThat(context.getContextFiles().size()).isEqualTo(2);
+  }
+
+  /**
+   * Tests v2.1 context configuration reading one template with one context.xml
+   *
+   */
+  @Test
+  public void testOldConfiguration() {
+
+    ContextConfigurationReader context = new ContextConfigurationReader(
+        Paths.get(new File(testFileRootPath + "valid_source_folder").toURI()));
+    assertThat(context.getContextFiles().size()).isEqualTo(1);
+  }
+
+  /**
+   * Tests if a conflict between old and new template structures occurred and an exception was thrown
+   *
+   * @throws InvalidConfigurationException if a conflict occurred
+   *
+   */
+  @Test(expected = InvalidConfigurationException.class)
+  public void testConflictConfiguration() throws InvalidConfigurationException {
+
+    new ContextConfigurationReader(Paths.get(new File(testFileRootPath + "invalid_new").toURI()));
   }
 
   /**

--- a/cobigen/cobigen-core/src/test/java/com/devonfw/cobigen/unittest/config/upgrade/ContextConfigurationUpgraderTest.java
+++ b/cobigen/cobigen-core/src/test/java/com/devonfw/cobigen/unittest/config/upgrade/ContextConfigurationUpgraderTest.java
@@ -31,12 +31,13 @@ public class ContextConfigurationUpgraderTest extends AbstractUnitTest {
   public TemporaryFolder tempFolder = new TemporaryFolder();
 
   /**
-   * Tests the valid upgrade of a templates configuration from version v1.2 to v2.1.
+   * Tests the valid upgrade of a context configuration from version v2.0 to latest version. Please make sure that
+   * .../ContextConfigurationUpgraderTest/valid-latest_version exists
    *
    * @throws Exception test fails
    */
   @Test
-  public void testCorrectUpgrade_v2_0_TO_v2_1() throws Exception {
+  public void testCorrectUpgrade_v2_0_TO_LATEST() throws Exception {
 
     // preparation
     File tmpTargetConfig = this.tempFolder.newFile(ConfigurationConstants.CONTEXT_CONFIG_FILENAME);
@@ -53,27 +54,27 @@ public class ContextConfigurationUpgraderTest extends AbstractUnitTest {
         .hasSameContentAs(sourceTestdata);
 
     version = sut.resolveLatestCompatibleSchemaVersion(this.tempFolder.getRoot().toPath());
-    assertThat(version).as("Target version").isEqualTo(ContextConfigurationVersion.v2_1);
+    assertThat(version).as("Target version").isEqualTo(ContextConfigurationVersion.getLatest());
 
     XMLUnit.setIgnoreWhitespace(true);
     new XMLTestCase() {
-    }.assertXMLEqual(new FileReader(testFileRootPath + "valid-v2.1/" + ConfigurationConstants.CONTEXT_CONFIG_FILENAME),
-        new FileReader(tmpTargetConfig));
+    }.assertXMLEqual(new FileReader(testFileRootPath + "valid-" + ContextConfigurationVersion.getLatest() + "/"
+        + ConfigurationConstants.CONTEXT_CONFIG_FILENAME), new FileReader(tmpTargetConfig));
   }
 
   /**
-   * Tests the valid upgrade of a templates configuration from version v1.2 to v2.1.
+   * Tests if latest context configuration is compatible to latest schema version.
    *
    * @throws Exception test fails
    */
   @Test
-  public void testCorrectV2_1SchemaDetection() throws Exception {
+  public void testCorrectLatestSchemaDetection() throws Exception {
 
     // preparation
-    File targetConfig = new File(testFileRootPath + "valid-v2.1");
+    File targetConfig = new File(testFileRootPath + "valid-" + ContextConfigurationVersion.getLatest());
 
     ContextConfigurationVersion version = new ContextConfigurationUpgrader()
         .resolveLatestCompatibleSchemaVersion(targetConfig.toPath());
-    assertThat(version).isEqualTo(ContextConfigurationVersion.v2_1);
+    assertThat(version).isEqualTo(ContextConfigurationVersion.getLatest());
   }
 }

--- a/cobigen/cobigen-core/src/test/resources/testdata/unittest/config/reader/ContextConfigurationReaderTest/invalid_new/src/main/templates/context.xml
+++ b/cobigen/cobigen-core/src/test/resources/testdata/unittest/config/reader/ContextConfigurationReaderTest/invalid_new/src/main/templates/context.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<contextConfiguration xmlns="http://capgemini.com/devonfw/cobigen/ContextConfiguration" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  version="2.1">
+  <trigger id="valid" type="java" templateFolder="valid">
+    <matcher type="fqn" value="*">
+    </matcher>
+  </trigger>
+</contextConfiguration>

--- a/cobigen/cobigen-core/src/test/resources/testdata/unittest/config/reader/ContextConfigurationReaderTest/invalid_new/src/main/templates/test_template/context.xml
+++ b/cobigen/cobigen-core/src/test/resources/testdata/unittest/config/reader/ContextConfigurationReaderTest/invalid_new/src/main/templates/test_template/context.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<contextConfiguration xmlns="http://capgemini.com/devonfw/cobigen/ContextConfiguration" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  version="2.2">
+  <trigger id="valid" type="java">
+    <matcher type="fqn" value="*">
+    </matcher>
+  </trigger>
+</contextConfiguration>

--- a/cobigen/cobigen-core/src/test/resources/testdata/unittest/config/reader/ContextConfigurationReaderTest/valid_new/src/main/templates/test_template/context.xml
+++ b/cobigen/cobigen-core/src/test/resources/testdata/unittest/config/reader/ContextConfigurationReaderTest/valid_new/src/main/templates/test_template/context.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<contextConfiguration xmlns="http://capgemini.com/devonfw/cobigen/ContextConfiguration" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  version="2.2">
+  <trigger id="valid" type="java">
+    <matcher type="fqn" value="*">
+    </matcher>
+  </trigger>
+</contextConfiguration>

--- a/cobigen/cobigen-core/src/test/resources/testdata/unittest/config/reader/ContextConfigurationReaderTest/valid_new/src/main/templates/test_template2/context.xml
+++ b/cobigen/cobigen-core/src/test/resources/testdata/unittest/config/reader/ContextConfigurationReaderTest/valid_new/src/main/templates/test_template2/context.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<contextConfiguration xmlns="http://capgemini.com/devonfw/cobigen/ContextConfiguration" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  version="2.2">
+  <trigger id="valid" type="java">
+    <matcher type="fqn" value="*">
+    </matcher>
+  </trigger>
+</contextConfiguration>

--- a/cobigen/cobigen-core/src/test/resources/testdata/unittest/config/upgrade/ContextConfigurationUpgraderTest/valid-v2.2/context.xml
+++ b/cobigen/cobigen-core/src/test/resources/testdata/unittest/config/upgrade/ContextConfigurationUpgraderTest/valid-v2.2/context.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<contextConfiguration xmlns="http://capgemini.com/devonfw/cobigen/ContextConfiguration" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  version="2.2">
+
+  <trigger id="valid" type="java" templateFolder="valid" inputCharset="UTF-8">
+    <matcher type="fqn" value="*" accumulationType="NOT">
+      <variableAssignment type="constant" key="foo" value="BLUBB1"/>
+      <variableAssignment type="constant" key="bar" value="BLAABB1"/>
+    </matcher>
+    <matcher type="fqn" value="*" accumulationType="OR">
+      <variableAssignment type="constant" key="foo" value="BLUBB2"/>
+      <variableAssignment type="constant" key="bar" value="BLAABB2"/>
+    </matcher>
+  </trigger>
+  <trigger id="valid2" type="java" templateFolder="valid" inputCharset="UTF-8">
+    <containerMatcher type="fqn" value="asdf.asd.fasdf.asfd." retrieveObjectsRecursively="true"/>
+    <matcher type="fqn" value="*" accumulationType="AND">
+      <variableAssignment type="constant" key="foo" value="BLUBB"/>
+    </matcher>
+  </trigger>
+
+</contextConfiguration>


### PR DESCRIPTION
made sure to throw an InvalidConfigurationException when a conflict between the old and new configuration occurred
added 3 new tests to ContextConfigurationReaderTest (one for 2.1, one for 2.2 and one for a conflict between them)
added new WikiConstants
updated ContextConfigurationUpdater/performNextUpgradeStep from 2.1 to 2.2
made upgrade tests more dynamic (tests use latest version instead of fixed 2.1)

Adresses/Fixes #1462.

Implements

* 
* 
* 

@devonfw/cobigen
